### PR TITLE
[FEAT] 메모 생성 구현

### DIFF
--- a/N_VoiceMemoApp_UIKit/Main/Main.storyboard
+++ b/N_VoiceMemoApp_UIKit/Main/Main.storyboard
@@ -309,6 +309,9 @@
                                         </constraints>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="Write_btn"/>
+                                        <connections>
+                                            <action selector="memoCreateButtonTapped:" destination="LXJ-8t-OpO" eventType="touchUpInside" id="ddS-IA-Z0F"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -446,7 +449,6 @@
         <!--Navigation Controller-->
         <scene sceneID="k9k-Z4-bIM">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Q4n-bC-HOh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="RMo-eT-WWT" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="" image="Memo_Off" selectedImage="Memo_On" id="4NT-bf-eDS"/>
                     <toolbarItems/>
@@ -459,6 +461,7 @@
                         <segue destination="LXJ-8t-OpO" kind="relationship" relationship="rootViewController" id="CTK-hg-zLf"/>
                     </connections>
                 </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Q4n-bC-HOh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-77.099236641221367" y="305.63380281690144"/>
         </scene>

--- a/N_VoiceMemoApp_UIKit/Memo/MemoCreate/MemoCreate.storyboard
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoCreate/MemoCreate.storyboard
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Memo Create View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="MemoCreateViewController" id="Y6W-OH-hqX" customClass="MemoCreateViewController" customModule="N_VoiceMemoApp_UIKit" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8e3-JV-tsg">
+                                <rect key="frame" x="30" y="164" width="147.33333333333334" height="62.333333333333343"/>
+                                <string key="text">메모를
+추가해 보세요.</string>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="제목을 입력하세요." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dN9-YV-3aU">
+                                <rect key="frame" x="30" y="246.33333333333334" width="105" height="18.666666666666657"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                            </textField>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="내용을 입력하세요." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="WTF-qJ-2RW">
+                                <rect key="frame" x="25" y="285" width="343" height="305"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" name="gray-2"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="현재 날짜 및 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LIk-dX-qsw">
+                                <rect key="frame" x="30" y="610" width="110" height="20"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <color key="textColor" name="icon-on"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="현재날짜 및 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hRj-JT-EKX">
+                                <rect key="frame" x="30" y="630" width="118" height="21"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                                <color key="textColor" name="key-color"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rx4-sV-mTx">
+                                <rect key="frame" x="31.666666666666657" y="690" width="330" height="44"/>
+                                <color key="backgroundColor" name="key-color"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                <inset key="contentEdgeInsets" minX="130" minY="10" maxX="130" maxY="10"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="생성하기"/>
+                                <connections>
+                                    <action selector="memoCreateButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="WRx-9t-jYz"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="WTF-qJ-2RW" secondAttribute="trailing" constant="25" id="3Yx-8O-irb"/>
+                            <constraint firstItem="LIk-dX-qsw" firstAttribute="top" secondItem="WTF-qJ-2RW" secondAttribute="bottom" constant="20" id="7rk-Ew-JPR"/>
+                            <constraint firstItem="hRj-JT-EKX" firstAttribute="top" secondItem="LIk-dX-qsw" secondAttribute="bottom" id="83u-hH-T9L"/>
+                            <constraint firstItem="Rx4-sV-mTx" firstAttribute="centerX" secondItem="vDu-zF-Fre" secondAttribute="centerX" id="98D-Af-zOw"/>
+                            <constraint firstItem="hRj-JT-EKX" firstAttribute="leading" secondItem="LIk-dX-qsw" secondAttribute="leading" id="9aa-h2-oCE"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="Rx4-sV-mTx" secondAttribute="bottom" constant="50" id="HA3-QZ-kJg"/>
+                            <constraint firstItem="8e3-JV-tsg" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="JXI-tH-BAJ"/>
+                            <constraint firstItem="Rx4-sV-mTx" firstAttribute="top" secondItem="WTF-qJ-2RW" secondAttribute="bottom" constant="100" id="LHi-sH-LlX"/>
+                            <constraint firstItem="WTF-qJ-2RW" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="25" id="P6M-WF-a4c"/>
+                            <constraint firstItem="LIk-dX-qsw" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="Q5D-6R-SBN"/>
+                            <constraint firstItem="dN9-YV-3aU" firstAttribute="top" secondItem="8e3-JV-tsg" secondAttribute="bottom" constant="20" id="WON-d2-wig"/>
+                            <constraint firstItem="dN9-YV-3aU" firstAttribute="leading" secondItem="8e3-JV-tsg" secondAttribute="leading" id="Wip-2o-CfE"/>
+                            <constraint firstItem="8e3-JV-tsg" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="46" id="a5R-hw-rCT"/>
+                            <constraint firstItem="WTF-qJ-2RW" firstAttribute="top" secondItem="dN9-YV-3aU" secondAttribute="bottom" constant="20" id="bxc-tc-qqS"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="contentTextView" destination="WTF-qJ-2RW" id="42Z-88-v2B"/>
+                        <outlet property="dateLabel" destination="hRj-JT-EKX" id="dkT-Ig-hlm"/>
+                        <outlet property="memoCreateButton" destination="Rx4-sV-mTx" id="dzl-gF-RwA"/>
+                        <outlet property="titleTextField" destination="dN9-YV-3aU" id="s37-ll-07D"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5.343511450381679" y="-2.1126760563380285"/>
+        </scene>
+    </scenes>
+    <resources>
+        <namedColor name="gray-2">
+            <color red="0.65490196078431373" green="0.65490196078431373" blue="0.65490196078431373" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="icon-on">
+            <color red="0.52156862745098043" green="0.52156862745098043" blue="0.52156862745098043" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="key-color">
+            <color red="0.12549019607843137" green="0.80784313725490198" blue="0.46666666666666667" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/N_VoiceMemoApp_UIKit/Memo/MemoCreate/MemoCreateViewController.swift
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoCreate/MemoCreateViewController.swift
@@ -1,0 +1,133 @@
+//
+//  MemoCreateViewController.swift
+//  N_VoiceMemoApp_UIKit
+//
+//  Created by wodnd on 5/6/25.
+//
+
+import UIKit
+
+struct memoCreateModel {
+    let id: String
+    let title: String
+    let content: String
+    let date: String
+}
+
+class MemoCreateViewController: UIViewController {
+
+    @IBOutlet weak var titleTextField: UITextField!
+    @IBOutlet weak var contentTextView: UITextView!
+    @IBOutlet weak var dateLabel: UILabel!
+    @IBOutlet weak var memoCreateButton: UIButton!
+    
+    let textViewPlaceHolder = "내용을 입력하세요."
+    
+    var onMemoCreated: (() -> Void)?  // ← 추가
+    
+    private var viewModel: MemoCreateViewModel = MemoCreateViewModel()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close,
+                                                                target: self,
+                                                                action: #selector(closeTapped))
+        
+        memoCreateButton.layer.cornerRadius = 10
+        titleTextField.delegate = self
+        contentTextView.delegate = self
+        setupDoneButtonOnKeyboard()
+        setTodayDateLabel()
+    }
+    
+    @objc func closeTapped() {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    private func setTodayDateLabel() {
+        let date = Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        dateFormatter.dateFormat = "yyyy년 M월 d일 (E) - a h시 mm분"
+
+        dateLabel.text = dateFormatter.string(from: date)
+    }
+    
+    private func setupDoneButtonOnKeyboard() {
+            let toolbar = UIToolbar()
+            toolbar.sizeToFit()
+            
+            let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            let doneButton = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(doneButtonTapped))
+            
+            toolbar.items = [flexibleSpace, doneButton]
+            contentTextView.inputAccessoryView = toolbar
+        }
+        
+        @objc private func doneButtonTapped() {
+            view.endEditing(true) // 키보드 내림
+        }
+    @IBAction func memoCreateButtonTapped(_ sender: Any) {
+        guard let title = titleTextField.text, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            let alert = UIAlertController(title: nil, message: "제목을 입력해주세요.", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "확인", style: .default))
+            present(alert, animated: true)
+            return
+        }
+        
+        let content = contentTextView.text ?? ""
+
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || content == textViewPlaceHolder {
+            let alert = UIAlertController(title: nil, message: "내용을 입력해주세요.", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "확인", style: .default))
+            present(alert, animated: true)
+            return
+        }
+        
+        let model = memoCreateModel(
+            id: UUID().uuidString,
+            title: title,
+            content: content,
+            date: dateLabel.text ?? "오늘"
+        )
+        
+        viewModel.process(.createMemo(model)) { [weak self] success in
+            guard let self = self else { return }
+            
+            let message = success ? "Memo 생성 완료!!" : "Memo 생성 실패!!"
+            let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "확인", style: .default) { _ in
+                if success {
+                    self.dismiss(animated: true)
+                    self.onMemoCreated?()  // ✅ 성공 시 콜백 호출
+                }
+            })
+            self.present(alert, animated: true)
+        }
+    }
+}
+
+extension MemoCreateViewController: UITextFieldDelegate{
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        titleTextField.endEditing(true)
+        return true
+    }
+}
+
+extension MemoCreateViewController: UITextViewDelegate{
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        
+        if contentTextView.text == textViewPlaceHolder {
+            contentTextView.text = nil
+            contentTextView.textColor = .bk
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if contentTextView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            contentTextView.text = textViewPlaceHolder
+            contentTextView.textColor = .gray2
+        }
+    }
+}

--- a/N_VoiceMemoApp_UIKit/Memo/MemoCreate/MemoCreateViewModel.swift
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoCreate/MemoCreateViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  MemoCreateViewModel.swift
+//  N_VoiceMemoApp_UIKit
+//
+//  Created by wodnd on 5/6/25.
+//
+
+import Foundation
+import FirebaseFirestore
+
+final class MemoCreateViewModel: ObservableObject{
+    enum Action {
+        case createMemo(memoCreateModel)
+    }
+    
+    final class State {
+        var createMemoViewModels: memoCreateModel?
+    }
+    
+    private(set) var state: State = State()
+    
+    func process(_ action: Action, completion: @escaping (Bool) -> Void) {
+        switch action {
+        case let .createMemo(memo):
+            saveMemoToFirestore(memo, completion: completion)
+        }
+    }
+    
+    func saveMemoToFirestore(_ memo: memoCreateModel, completion: @escaping (Bool) -> Void) {
+        let db = Firestore.firestore()
+        let memoData: [String: Any] = [
+            "id": memo.id,
+            "title": memo.title,
+            "content": memo.content,
+            "date": memo.date
+        ]
+        
+        let documentRef = db.collection("Memo").document("List")
+        
+        documentRef.updateData([
+            "memo": FieldValue.arrayUnion([memoData])
+        ]) { error in
+            if let error = error {
+                print("❌ 저장 실패: \(error.localizedDescription)")
+                completion(false)
+            } else {
+                print("✅ Firestore 저장 성공!")
+                completion(true)
+            }
+        }
+    }
+}

--- a/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoCell.swift
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoCell.swift
@@ -12,7 +12,6 @@ struct MemoCellViewModel: Hashable {
     let title: String
     let content: String
     let date: String
-    let time: String
 }
 
 
@@ -41,7 +40,7 @@ class MemoCell: UICollectionViewCell {
     
     func configure(_ viewModel: MemoCellViewModel, _ isFirst: Bool = false, _ isLast: Bool = false) {
         titleLabel.text = viewModel.title
-        dateLabel.text = "\(viewModel.date) - \(viewModel.time)"
+        dateLabel.text = viewModel.date
         
         
         // ✅ topBorder는 항상 첫 셀만

--- a/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoModel.swift
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoModel.swift
@@ -16,7 +16,6 @@ struct memo: Codable {
     let title: String
     let content: String
     let date: String
-    let time: String
 }
 
 

--- a/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoViewController.swift
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoViewController.swift
@@ -115,4 +115,19 @@ class MemoViewController: UIViewController {
             subTitleLabel.alpha = 1
         }
     }
+    
+    @IBAction func memoCreateButtonTapped(_ sender: Any) {
+        let storyboard = UIStoryboard(name: "MemoCreate", bundle: nil)
+        guard let memoCreateVC = storyboard.instantiateViewController(withIdentifier: "MemoCreateViewController") as? MemoCreateViewController else { return }
+        
+        //TodoCreateViewController를 NavigationController로 감싸서 present 자동으로 < 뒤로가기 버튼이 생김
+        let nav = UINavigationController(rootViewController: memoCreateVC)
+        nav.modalPresentationStyle = .fullScreen
+        
+        // ✅ 콜백으로 데이터 다시 불러오기
+        memoCreateVC.onMemoCreated = { [weak self] in
+            self?.viewModel.process(.loadData)
+        }
+        self.present(nav, animated: true)
+    }
 }

--- a/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoViewModel.swift
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoViewModel.swift
@@ -69,19 +69,19 @@ extension MemoViewModel {
         Task {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "ko_KR")
-            formatter.dateFormat = "a h시 mm분" // 예: 오후 6시 40분
+            formatter.dateFormat = "yyyy년 M월 d일 (E) - a h시 mm분" // 전체 날짜+시간 포맷으로 수정
             
-            let sortedResponse = response.memo.sorted { todo1, todo2 in
+            let sortedResponse = response.memo.sorted { memo1, memo2 in
                 guard
-                    let date1 = formatter.date(from: todo1.time),
-                    let date2 = formatter.date(from: todo2.time)
+                    let date1 = formatter.date(from: memo1.date),
+                    let date2 = formatter.date(from: memo2.date)
                 else {
                     return false
                 }
                 return date1 < date2
             }
             state.viewModels.memoViewModels = sortedResponse.map{
-                MemoCellViewModel(id: $0.id, title: $0.title, content: $0.content, date: $0.date, time: $0.time)
+                MemoCellViewModel(id: $0.id, title: $0.title, content: $0.content, date: $0.date)
             }
         }
     }

--- a/N_VoiceMemoApp_UIKit/Todo/TodoCreate/TodoCreate.storyboard
+++ b/N_VoiceMemoApp_UIKit/Todo/TodoCreate/TodoCreate.storyboard
@@ -28,10 +28,10 @@
                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="제목을 입력하세요." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Ab-KE-yDs">
                                 <rect key="frame" x="30" y="246.33333333333334" width="134" height="23.333333333333343"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                <textInputTraits key="textInputTraits"/>
+                                <textInputTraits key="textInputTraits" returnKeyType="done"/>
                             </textField>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="wheels" translatesAutoresizingMaskIntoConstraints="NO" id="Mzv-ng-2UD">
-                                <rect key="frame" x="0.0" y="270" width="393" height="216"/>
+                                <rect key="frame" x="0.0" y="269.66666666666669" width="393" height="216"/>
                                 <locale key="locale" localeIdentifier="ko_KR"/>
                             </datePicker>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="날짜" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wUq-9p-C3V">

--- a/N_VoiceMemoApp_UIKit/Todo/TodoCreate/TodoCreateViewController.swift
+++ b/N_VoiceMemoApp_UIKit/Todo/TodoCreate/TodoCreateViewController.swift
@@ -33,7 +33,7 @@ class TodoCreateViewController: UIViewController {
                                                                 action: #selector(closeTapped))
         todoCreateButton.layer.cornerRadius = 10
         setTodayDateLabel()
-        setupDoneButtonOnKeyboard()
+        titleTextField.delegate = self
     }
     
     @objc func closeTapped() {
@@ -85,19 +85,11 @@ class TodoCreateViewController: UIViewController {
             self.present(alert, animated: true)
         }
     }
-    
-    private func setupDoneButtonOnKeyboard() {
-        let toolbar = UIToolbar()
-        toolbar.sizeToFit()
-        
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        let doneButton = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(doneButtonTapped))
-        
-        toolbar.items = [flexibleSpace, doneButton]
-        titleTextField.inputAccessoryView = toolbar
-    }
-    
-    @objc private func doneButtonTapped() {
-        view.endEditing(true) // 키보드 내림
+}
+
+extension TodoCreateViewController: UITextFieldDelegate{
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        titleTextField.endEditing(true)
+        return true
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
1. [FEAT] 메모 생성 구현 #3

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
1. 메모 생성 구현

## ‼️ TODO
<!-- 해결하지 못했거나 추후 해야할 일에 대한 설명을 적어주세요 -->

## 📸 코드 및 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
1. 메모 생성 구현
<img width="232" alt="스크린샷 2025-04-20 오전 12 22 52" src="https://github.com/user-attachments/assets/b6b974e4-6257-4f22-9435-f5244f6d4c8b" />

2. 키보드 내림 수정
제목 입력은 UITextFieldDelegate의 textFieldShouldReturn을 활용해 키보드를 내리도록 수정하였고,
내용 입력은 UITextView에서 줄바꿈 기능을 유지하기 위해 커스텀 완료 버튼을 키보드 상단에 추가해 키보드 내림을 구현했습니다.
기존에 Todo 제목 입력에서도 사용하던 커스텀 키보드 내림 방식은 제거하고 delegate 방식으로 통일하여 보다 깔끔한 UX를 구현했습니다.
<div>
<img width="232" alt="스크린샷 2025-04-20 오전 12 22 52" src="https://github.com/user-attachments/assets/38b46ee4-8ccc-442a-abf2-e75d442c0c5f" />
<img width="232" alt="스크린샷 2025-04-20 오전 12 22 52" src="https://github.com/user-attachments/assets/ed75e6b0-da50-4ed0-9d85-7c3ad800b72f" />
</div>

```Swift
//기존 커스텀 키보드 내림
private func setupDoneButtonOnKeyboard() {
            let toolbar = UIToolbar()
            toolbar.sizeToFit()
            
            let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
            let doneButton = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(doneButtonTapped))
            
            toolbar.items = [flexibleSpace, doneButton]
            contentTextView.inputAccessoryView = toolbar
        }
        
        @objc private func doneButtonTapped() {
            view.endEditing(true) // 키보드 내림
        }
```

```Swift
//delegate를 활용한 키보드 내림
extension MemoCreateViewController: UITextFieldDelegate{
    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
        titleTextField.endEditing(true)
        return true
    }
}
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
### ✅ 키보드 처리 개선

- 기존에는 텍스트 입력 후 키보드를 내리기 위해 `UITextView`와 `UITextField` 모두 커스텀 `완료` 버튼을 툴바에 추가해 처리.
- 이번 수정에서는 `UITextField`는 **Delegate의 `textFieldShouldReturn`** 메서드를 사용해 **엔터 키로 키보드 내림**을 구현.
- 반면, `UITextView`는 다음 줄 입력이 필요하므로 기존처럼 커스텀 툴바를 유지하여 키보드 내림 버튼을 제공.