### PR TITLE
[FEAT] 메모 상세화면 구현

### DIFF
--- a/N_VoiceMemoApp_UIKit/Memo/MemoDetail/MemoDetail.storyboard
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoDetail/MemoDetail.storyboard
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Memo Detail View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="MemoDetailViewController" id="Y6W-OH-hqX" customClass="MemoDetailViewController" customModule="N_VoiceMemoApp_UIKit" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Aul-yT-Ytt">
+                                <rect key="frame" x="30" y="157" width="45" height="32"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="날짜" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iSI-Eh-2Su">
+                                <rect key="frame" x="30" y="209" width="35" height="24"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
+                                <color key="textColor" name="key-color"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="내용" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fWY-gn-owj">
+                                <rect key="frame" x="30" y="263" width="29.666666666666671" height="20.333333333333314"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fWY-gn-owj" secondAttribute="trailing" constant="30" id="Egz-h0-NoC"/>
+                            <constraint firstItem="iSI-Eh-2Su" firstAttribute="leading" secondItem="Aul-yT-Ytt" secondAttribute="leading" id="Jj3-Ff-ctr"/>
+                            <constraint firstItem="iSI-Eh-2Su" firstAttribute="top" secondItem="Aul-yT-Ytt" secondAttribute="bottom" constant="20" id="MX1-sx-jjY"/>
+                            <constraint firstItem="fWY-gn-owj" firstAttribute="top" secondItem="iSI-Eh-2Su" secondAttribute="bottom" constant="30" id="R7U-Jf-jx3"/>
+                            <constraint firstItem="Aul-yT-Ytt" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="g6O-2k-So0"/>
+                            <constraint firstItem="fWY-gn-owj" firstAttribute="leading" secondItem="iSI-Eh-2Su" secondAttribute="leading" id="ktb-gG-U4P"/>
+                            <constraint firstItem="Aul-yT-Ytt" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="39" id="qFr-Oc-gMA"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="contentLabel" destination="fWY-gn-owj" id="rh1-c5-mgq"/>
+                        <outlet property="dateLabel" destination="iSI-Eh-2Su" id="niw-js-a32"/>
+                        <outlet property="titleLabel" destination="Aul-yT-Ytt" id="mFu-9e-rJg"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="117" y="-2"/>
+        </scene>
+    </scenes>
+    <resources>
+        <namedColor name="key-color">
+            <color red="0.12549019607843137" green="0.80784313725490198" blue="0.46666666666666667" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/N_VoiceMemoApp_UIKit/Memo/MemoDetail/MemoDetailViewController.swift
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoDetail/MemoDetailViewController.swift
@@ -1,0 +1,28 @@
+//
+//  MemoDetailViewController.swift
+//  N_VoiceMemoApp_UIKit
+//
+//  Created by wodnd on 5/9/25.
+//
+
+import UIKit
+
+class MemoDetailViewController: UIViewController {
+    var memoID: String?
+    var memoTitle: String?
+    var memoContent: String?
+    var memoDate: String?
+    
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var dateLabel: UILabel!
+    @IBOutlet weak var contentLabel: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        titleLabel.text = memoTitle
+        dateLabel.text = memoDate
+        contentLabel.text = memoContent
+    }
+
+}

--- a/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoViewController.swift
+++ b/N_VoiceMemoApp_UIKit/Memo/MemoList/MemoViewController.swift
@@ -38,6 +38,7 @@ class MemoViewController: UIViewController {
         
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
         collectionView.addGestureRecognizer(longPressGesture)
+        collectionView.delegate = self
     }
     
     private func bindingViewModel() {
@@ -143,7 +144,7 @@ class MemoViewController: UIViewController {
             let cellViewModel = viewModel.state.viewModels.memoViewModels[indexPath.row]
             
             let alert = UIAlertController(title: "삭제하시겠습니까?",
-                                          message: "\"\(cellViewModel.title)\" 할 일을 삭제할까요?",
+                                          message: "\"\(cellViewModel.title)\" 메모를 삭제할까요?",
                                           preferredStyle: .alert)
             
             alert.addAction(UIAlertAction(title: "삭제", style: .destructive) { _ in
@@ -154,5 +155,22 @@ class MemoViewController: UIViewController {
             
             self.present(alert, animated: true)
         }
+    }
+}
+
+extension MemoViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        let selectedMemo = viewModel.state.viewModels.memoViewModels[indexPath.row]
+        
+        let storyboard = UIStoryboard(name: "MemoDetail", bundle: nil)
+        let detailVC = storyboard.instantiateViewController(withIdentifier: "MemoDetailViewController") as! MemoDetailViewController
+        
+        detailVC.memoTitle = selectedMemo.title
+        detailVC.memoID = selectedMemo.id
+        detailVC.memoContent = selectedMemo.content
+        detailVC.memoDate = selectedMemo.date
+        
+        present(detailVC, animated: true)
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
1. [FEAT] 메모 상세화면 구현 #7

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
1. 메모 상세화면 구현

## ‼️ TODO
<!-- 해결하지 못했거나 추후 해야할 일에 대한 설명을 적어주세요 -->

## 📸 코드 및 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
1. 메모 상세화면 구현
<img width="232" alt="스크린샷 2025-05-09 오후 2 52 04" src="https://github.com/user-attachments/assets/ac29edab-8481-4e60-a47b-ebc0459994e7" />

``` Swift
extension MemoViewController: UICollectionViewDelegate {
    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
        
        let selectedMemo = viewModel.state.viewModels.memoViewModels[indexPath.row]
        
        let storyboard = UIStoryboard(name: "MemoDetail", bundle: nil)
        let detailVC = storyboard.instantiateViewController(withIdentifier: "MemoDetailViewController") as! MemoDetailViewController
        
        detailVC.memoTitle = selectedMemo.title
        detailVC.memoID = selectedMemo.id
        detailVC.memoContent = selectedMemo.content
        detailVC.memoDate = selectedMemo.date
        
        present(detailVC, animated: true)
    }
}
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
